### PR TITLE
Mission priority access

### DIFF
--- a/Include/TSEMissions.h
+++ b/Include/TSEMissions.h
@@ -27,7 +27,8 @@ class CMission : public CSpaceObject
 					bIncludeActive(false),
 					bIncludeRecorded(false),
 					bOnlySourceOwner(false),
-					bOnlySourceDebriefer(false)
+					bOnlySourceDebriefer(false),
+					bPriorityOnly(false)
 				{ }
 
 			bool bIncludeOpen;					//	Include open missions
@@ -37,6 +38,7 @@ class CMission : public CSpaceObject
 
 			bool bOnlySourceOwner;				//	Source must be owner
 			bool bOnlySourceDebriefer;			//	Source must be debriefer
+			bool bPriorityOnly;					//	Return highest priority mission
 
 			TArray<CString> AttribsRequired;	//	Required attributes
 			TArray<CString> AttribsNotAllowed;	//	Exclude objects with these attributes
@@ -51,6 +53,7 @@ class CMission : public CSpaceObject
 							   CString *retsError);
 		void FireCustomEvent (const CString &sEvent, ICCItem *pData);
 		inline DWORD GetAcceptedOn (void) const { return m_dwAcceptedOn; }
+		inline int GetPriority (void) const { return m_pType->GetPriority(); }
 		inline bool IsActive (void) const { return (m_iStatus == statusAccepted || (!m_fDebriefed && (m_iStatus == statusPlayerSuccess || m_iStatus == statusPlayerFailure))); }
 		inline bool IsClosed (void) const { return (!IsActive() && IsCompleted()); }
 		inline bool IsCompleted (void) const { return (m_iStatus == statusPlayerSuccess || m_iStatus == statusPlayerFailure || m_iStatus == statusSuccess || m_iStatus == statusFailure); }

--- a/TSE/CCExtensions.cpp
+++ b/TSE/CCExtensions.cpp
@@ -2216,6 +2216,8 @@ static PRIMITIVEPROCDEF g_Extensions[] =
 			"   o                  Include open missions\n"
 			"   r                  Include already debriefed (recorded) missions\n"
 			"   u                  Include non-player missions\n"
+			"   D                  Only missions debriefed by source\n"
+			"   P                  Return only the mission with highest priority\n"
 			"   S                  Only missions owned by source\n"
 			"   +/-{attrib}        Require/exclude missions with given attribute\n"
 			"   +/-ownerID:{id}    Require/exclude missions with given owner\n"
@@ -2258,6 +2260,7 @@ static PRIMITIVEPROCDEF g_Extensions[] =
 			"   'name              The name of the mission\n"
 			"   'nodeID            ID of the mission's owner system\n"
 			"   'ownerID           ID of the mission's owner object\n"
+			"   'priority          Mission priority\n"
 			"   'summary           A summary description of the mission\n"
 			"   'unid              Mission type UNID",
 
@@ -8193,19 +8196,37 @@ ICCItem *fnMission (CEvalContext *pEvalCtx, ICCItem *pArgs, DWORD dwData)
 			if (List.GetCount() == 0)
 				return pCC->CreateNil();
 
-			//	Create a list to return
+			if (Criteria.bPriorityOnly)
+				{
+				//	Return a single mission
 
-			ICCItem *pResult = pCC->CreateLinkedList();
-			if (pResult->IsError())
+				int bestPriority = -1;
+				j = 0;
+				for (i = 0; i < List.GetCount(); i++)
+					if (List[i]->GetPriority() > bestPriority)
+						{
+						j = i;
+						bestPriority = List[i]->GetPriority();
+						}
+				
+				return pCC->CreateInteger((int)List[j]);
+				}
+			else
+				{
+				//	Create a list to return
+
+				ICCItem *pResult = pCC->CreateLinkedList();
+				if (pResult->IsError())
+					return pResult;
+
+				CCLinkedList *pList = (CCLinkedList *)pResult;
+				for (i = 0; i < List.GetCount(); i++)
+					pList->AppendInteger(*pCC, (int)List[i]);
+
+				//	Done
+
 				return pResult;
-
-			CCLinkedList *pList = (CCLinkedList *)pResult;
-			for (i = 0; i < List.GetCount(); i++)
-				pList->AppendInteger(*pCC, (int)List[i]);
-
-			//	Done
-
-			return pResult;
+				}
 			}
 
 		default:

--- a/TSE/CMission.cpp
+++ b/TSE/CMission.cpp
@@ -32,6 +32,7 @@ static CObjectClass<CMission>g_MissionClass(OBJID_CMISSION, NULL);
 #define PROPERTY_NAME							CONSTLIT("name")
 #define PROPERTY_NODE_ID						CONSTLIT("nodeID")
 #define PROPERTY_OWNER_ID						CONSTLIT("ownerID")
+#define PROPERTY_PRIORITY						CONSTLIT("priority")
 #define PROPERTY_SUMMARY						CONSTLIT("summary")
 #define PROPERTY_UNID							CONSTLIT("unid")
 
@@ -538,6 +539,9 @@ ICCItem *CMission::GetProperty (CCodeChainCtx &Ctx, const CString &sName)
 			return CC.CreateInteger(m_pOwner.GetID());
 		}
 
+	else if (strEquals(sName, PROPERTY_PRIORITY))
+		return CC.CreateInteger(m_pType->GetPriority());
+
 	else if (strEquals(sName, PROPERTY_SUMMARY))
 		return CC.CreateString(m_sInstructions);
 
@@ -1043,6 +1047,10 @@ bool CMission::ParseCriteria (const CString &sCriteria, SCriteria *retCriteria)
 
 			case 'D':
 				retCriteria->bOnlySourceDebriefer = true;
+				break;
+
+			case 'P':
+				retCriteria->bPriorityOnly = true;
 				break;
 
 			case 'S':


### PR DESCRIPTION
Mission priority is now a property accesible via `msnGetProperty`
Adds new `P` criteria to `msnFind` to return just the highest priority mission

See [Active/open missions should be displayed in order of priority](https://ministry.kronosaur.com/record.hexm?id=73564)