### PR TITLE
Added support for arc-limited AutoDefenseDevices.

### DIFF
--- a/Include/TSEDeviceClassesImpl.h
+++ b/Include/TSEDeviceClassesImpl.h
@@ -38,20 +38,20 @@ class CAutoDefenseClass : public CDeviceClass
 		CAutoDefenseClass (void);
 
 		inline CDeviceClass *GetWeapon (void) const { return m_pWeapon; }
+		bool IsDirectional (CInstalledDevice *pDevice, int *retiMinFireArc, int *retiMaxFireArc);
+		bool IsOmniDirectional (CInstalledDevice *pDevice);
 
 
 		TargetingSystemTypes m_iTargeting;
 		CSpaceObject::Criteria m_TargetCriteria;
 		Metric m_rInterceptRange;
 
-		int m_iRechargeTicks;
-		CDeviceClassRef m_pWeapon;
-
 		bool m_bOmnidirectional;				//	Omnidirectional
 		int m_iMinFireArc;						//	Min angle of fire arc (degrees)
 		int m_iMaxFireArc;						//	Max angle of fire arc (degrees)
-		bool IsOmniDirectional(CInstalledDevice *pDevice);
-		bool IsDirectional(CInstalledDevice *pDevice, int *retiMinFireArc, int *retiMaxFireArc);
+		int m_iRechargeTicks;
+		CDeviceClassRef m_pWeapon;
+
 
 	};
 

--- a/Include/TSEDeviceClassesImpl.h
+++ b/Include/TSEDeviceClassesImpl.h
@@ -39,12 +39,20 @@ class CAutoDefenseClass : public CDeviceClass
 
 		inline CDeviceClass *GetWeapon (void) const { return m_pWeapon; }
 
+
 		TargetingSystemTypes m_iTargeting;
 		CSpaceObject::Criteria m_TargetCriteria;
 		Metric m_rInterceptRange;
 
 		int m_iRechargeTicks;
 		CDeviceClassRef m_pWeapon;
+
+		bool m_bOmnidirectional;				//	Omnidirectional
+		int m_iMinFireArc;						//	Min angle of fire arc (degrees)
+		int m_iMaxFireArc;						//	Max angle of fire arc (degrees)
+		bool IsOmniDirectional(CInstalledDevice *pDevice);
+		bool IsDirectional(CInstalledDevice *pDevice, int *retiMinFireArc, int *retiMaxFireArc);
+
 	};
 
 class CCargoSpaceClass : public CDeviceClass

--- a/TSE/CAutoDefenseClass.cpp
+++ b/TSE/CAutoDefenseClass.cpp
@@ -18,6 +18,12 @@
 #define PROPERTY_FIRE_RATE						CONSTLIT("fireRate")
 #define PROPERTY_ENABLED						CONSTLIT("enabled")
 #define PROPERTY_EXTERNAL						CONSTLIT("external")
+#define PROPERTY_FIRE_ARC						CONSTLIT("fireArc")
+#define PROPERTY_OMNIDIRECTIONAL				CONSTLIT("omnidirectional")
+#define MAX_FIRE_ARC_ATTRIB						CONSTLIT("maxFireArc")
+#define MIN_FIRE_ARC_ATTRIB						CONSTLIT("minFireArc")
+#define OMNIDIRECTIONAL_ATTRIB					CONSTLIT("omnidirectional")
+
 
 const int DEFAULT_INTERCEPT_RANGE =				10;
 
@@ -100,6 +106,51 @@ ICCItem *CAutoDefenseClass::FindItemProperty (CItemCtx &Ctx, const CString &sPro
 	else if (strEquals(sProperty, PROPERTY_EXTERNAL))
 		return CC.CreateBool(pDevice ? pDevice->IsExternal() : IsExternal());
 
+	else if (strEquals(sProperty, PROPERTY_OMNIDIRECTIONAL))
+	{
+		return CC.CreateBool(IsOmniDirectional(pDevice));
+	}
+
+	else if (strEquals(sProperty, PROPERTY_FIRE_ARC))
+	{
+		int iMinFireArc;
+		int iMaxFireArc;
+
+		//	Omnidirectional
+
+		if (IsOmniDirectional(pDevice))
+			return CC.CreateString(PROPERTY_OMNIDIRECTIONAL);
+
+		//	Fire arc
+
+		else if (IsDirectional(pDevice, &iMinFireArc, &iMaxFireArc))
+		{
+			//	Create a list
+
+			ICCItem *pResult = CC.CreateLinkedList();
+			if (pResult->IsError())
+				return pResult;
+
+			CCLinkedList *pList = (CCLinkedList *)pResult;
+
+			pList->AppendInteger(CC, iMinFireArc);
+			pList->AppendInteger(CC, iMaxFireArc);
+
+			return pResult;
+		}
+
+		//	Otherwise, see if we are pointing in a particular direction
+
+		else
+		{
+			int iFacingAngle = AngleMod((pDevice ? pDevice->GetRotation() : 0) + AngleMiddle(m_iMinFireArc, m_iMaxFireArc));
+			if (iFacingAngle == 0)
+				return CC.CreateNil();
+			else
+				return CC.CreateInteger(iFacingAngle);
+		}
+	}
+
 	//	Otherwise, just get the property from the weapon we're using
 
 	else if (pWeapon = GetWeapon())
@@ -169,6 +220,92 @@ CString CAutoDefenseClass::OnGetReference (CItemCtx &Ctx, const CItem &Ammo, DWO
 		return NULL_STR;
 	}
 
+bool CAutoDefenseClass::IsDirectional(CInstalledDevice *pDevice, int *retiMinFireArc, int *retiMaxFireArc)
+
+//	IsDirectional
+//
+//	Returns TRUE if the autodefensedevice can turn but is not omni
+//  Copied from CWeaponClass.cpp
+
+{
+	//	If the weapon is omnidirectional then we don't need directional
+	//	calculations.
+
+	if (m_bOmnidirectional || (pDevice && pDevice->IsOmniDirectional()))
+		return false;
+
+	//	If we have a device, combine the fire arcs of device slot and 
+	//  autodefensedevice
+
+	if (pDevice)
+	{
+		//	If the device is directional then we always take the fire arc from
+		//	the device slot.
+
+		if (pDevice->IsDirectional())
+		{
+			if (retiMinFireArc)
+				*retiMinFireArc = pDevice->GetMinFireArc();
+			if (retiMaxFireArc)
+				*retiMaxFireArc = pDevice->GetMaxFireArc();
+
+			return true;
+		}
+
+		//	Otherwise, see if the autodefensedevice is directional.
+
+		else if (m_iMinFireArc != m_iMaxFireArc)
+		{
+			//	If the device points in a specific direction then we offset the
+			//	autodefensedevice's fire arc.
+
+			int iDeviceSlotOffset = pDevice->GetMinFireArc();
+
+			if (retiMinFireArc)
+				*retiMinFireArc = (m_iMinFireArc + iDeviceSlotOffset) % 360;
+			if (retiMaxFireArc)
+				*retiMaxFireArc = (m_iMaxFireArc + iDeviceSlotOffset) % 360;
+
+			return true;
+		}
+
+		//	Otherwise, we are not directional
+
+		else
+			return false;
+	}
+	else
+	{
+		//	Otherwise, just check the autodefensedevice
+
+		if (retiMinFireArc)
+			*retiMinFireArc = m_iMinFireArc;
+		if (retiMaxFireArc)
+			*retiMaxFireArc = m_iMaxFireArc;
+
+		return (m_iMinFireArc != m_iMaxFireArc);
+	}
+}
+
+bool CAutoDefenseClass::IsOmniDirectional(CInstalledDevice *pDevice)
+
+//	IsOmniDirectional
+//
+//	Returns TRUE if the autodefensedevice is omnidirectional (not limited)
+//  Copied from CWeaponClass.cpp
+
+{
+	//	The device slot improves the autodefensedevice. If the device slot is
+	//  directional, then the autodefensedevice is directional. If the device
+	//  slot is omni directional, then the autodefensedevice is
+	//  omnidirectional.
+
+	if (pDevice && pDevice->IsOmniDirectional())
+		return true;
+
+	return m_bOmnidirectional;
+}
+
 void CAutoDefenseClass::Update (CInstalledDevice *pDevice, CSpaceObject *pSource, SDeviceUpdateCtx &Ctx)
 
 //	Update
@@ -191,12 +328,34 @@ void CAutoDefenseClass::Update (CInstalledDevice *pDevice, CSpaceObject *pSource
 	if (pDevice->IsReady() && pDevice->IsEnabled())
 		{
 		int i;
+		bool isOmniDirectional = false;
+		int iMinFireArc, iMaxFireArc;
 
 		//	Look for a target 
 
 		CSpaceObject *pBestTarget = NULL;
 		CSystem *pSystem = pSource->GetSystem();
 		CVector vSourcePos = pDevice->GetPos(pSource);
+
+		//  Find out whether our autoDefenseDevice is omnidirectional,
+		//  directional or has a fixed angle
+
+		if (IsOmniDirectional(pDevice))
+			isOmniDirectional = true;
+
+		//  If not omnidirectional, check directional. If not, then
+		//  our device points in one direction
+
+		else if (!IsDirectional(pDevice, &iMinFireArc, &iMaxFireArc)) {
+			iMinFireArc = AngleMod((pDevice ? pDevice->GetRotation() : 0)
+				+ AngleMiddle(m_iMinFireArc, m_iMaxFireArc));
+			iMaxFireArc = iMinFireArc;
+		}
+
+		//  Calculate min/max fire arcs given the object's rotation
+
+		iMinFireArc = (pSource->GetRotation() + iMinFireArc) % 360;
+		iMaxFireArc = (pSource->GetRotation() + iMaxFireArc) % 360;
 
 		//	Use the appropriate targeting method
 
@@ -216,7 +375,9 @@ void CAutoDefenseClass::Update (CInstalledDevice *pDevice, CSpaceObject *pSource
 							&& pObj->GetCategory() == CSpaceObject::catMissile
 							&& !pObj->GetDamageSource().IsEqual(pSource)
 							&& !pObj->IsIntangible()
-							&& pSource->IsEnemy(pObj->GetDamageSource()))
+							&& pSource->IsEnemy(pObj->GetDamageSource())
+							&& (AngleInArc(VectorToPolar((pObj->GetPos() - vSourcePos)), iMinFireArc, iMaxFireArc) ||
+								isOmniDirectional))
 						{
 						CVector vRange = pObj->GetPos() - vSourcePos;
 						Metric rDistance2 = vRange.Dot(vRange);
@@ -255,13 +416,14 @@ void CAutoDefenseClass::Update (CInstalledDevice *pDevice, CSpaceObject *pSource
 					{
 					CSpaceObject *pObj = pSystem->GetObject(i);
 					Metric rDistance2;
-
 					if (pObj
 							&& (m_TargetCriteria.dwCategories & pObj->GetCategory())
 							&& ((rDistance2 = (pObj->GetPos() - vSourcePos).Length2()) < rBestDist2)
 							&& pObj->MatchesCriteria(Ctx, m_TargetCriteria)
 							&& !pObj->IsIntangible()
-							&& pObj != pSource)
+							&& pObj != pSource
+							&& (AngleInArc(VectorToPolar((pObj->GetPos() - vSourcePos)), iMinFireArc, iMaxFireArc) ||
+								isOmniDirectional))
 						{
 						pBestTarget = pObj;
 						rBestDist2 = rDistance2;
@@ -323,6 +485,14 @@ ALERROR CAutoDefenseClass::CreateFromXML (SDesignLoadCtx &Ctx, CXMLElement *pDes
 		iFireRate = pDesc->GetAttributeInteger(RECHARGE_TIME_ATTRIB);
 	if (iFireRate == 0)
 		iFireRate = 15;
+
+	pDevice->m_iMinFireArc = AngleMod(pDesc->GetAttributeInteger(MIN_FIRE_ARC_ATTRIB));
+	pDevice->m_iMaxFireArc = AngleMod(pDesc->GetAttributeInteger(MAX_FIRE_ARC_ATTRIB));
+
+	//  Set omnidirectional if either the "omnidirectional" attribute is True, OR
+	//  if minfirearc = maxfirearc = 0.
+	pDevice->m_bOmnidirectional = (pDesc->GetAttributeBool(OMNIDIRECTIONAL_ATTRIB) ||
+		((pDevice->m_iMaxFireArc == pDevice->m_iMinFireArc) && pDevice->m_iMaxFireArc == 0));
 
 	pDevice->m_iRechargeTicks = (int)((iFireRate / STD_SECONDS_PER_UPDATE) + 0.5);
 	if (error = pDevice->m_pWeapon.LoadUNID(Ctx, pDesc->GetAttribute(WEAPON_ATTRIB)))

--- a/TSE/CAutoDefenseClass.cpp
+++ b/TSE/CAutoDefenseClass.cpp
@@ -11,6 +11,9 @@
 #define TARGET_ATTRIB							CONSTLIT("target")
 #define TARGET_CRITERIA_ATTRIB					CONSTLIT("targetCriteria")
 #define WEAPON_ATTRIB							CONSTLIT("weapon")
+#define MAX_FIRE_ARC_ATTRIB						CONSTLIT("maxFireArc")
+#define MIN_FIRE_ARC_ATTRIB						CONSTLIT("minFireArc")
+#define OMNIDIRECTIONAL_ATTRIB					CONSTLIT("omnidirectional")
 
 #define MISSILES_TARGET							CONSTLIT("missiles")
 
@@ -20,9 +23,6 @@
 #define PROPERTY_EXTERNAL						CONSTLIT("external")
 #define PROPERTY_FIRE_ARC						CONSTLIT("fireArc")
 #define PROPERTY_OMNIDIRECTIONAL				CONSTLIT("omnidirectional")
-#define MAX_FIRE_ARC_ATTRIB						CONSTLIT("maxFireArc")
-#define MIN_FIRE_ARC_ATTRIB						CONSTLIT("minFireArc")
-#define OMNIDIRECTIONAL_ATTRIB					CONSTLIT("omnidirectional")
 
 
 const int DEFAULT_INTERCEPT_RANGE =				10;
@@ -107,12 +107,10 @@ ICCItem *CAutoDefenseClass::FindItemProperty (CItemCtx &Ctx, const CString &sPro
 		return CC.CreateBool(pDevice ? pDevice->IsExternal() : IsExternal());
 
 	else if (strEquals(sProperty, PROPERTY_OMNIDIRECTIONAL))
-	{
 		return CC.CreateBool(IsOmniDirectional(pDevice));
-	}
 
 	else if (strEquals(sProperty, PROPERTY_FIRE_ARC))
-	{
+		{
 		int iMinFireArc;
 		int iMaxFireArc;
 
@@ -124,7 +122,7 @@ ICCItem *CAutoDefenseClass::FindItemProperty (CItemCtx &Ctx, const CString &sPro
 		//	Fire arc
 
 		else if (IsDirectional(pDevice, &iMinFireArc, &iMaxFireArc))
-		{
+			{
 			//	Create a list
 
 			ICCItem *pResult = CC.CreateLinkedList();
@@ -137,19 +135,19 @@ ICCItem *CAutoDefenseClass::FindItemProperty (CItemCtx &Ctx, const CString &sPro
 			pList->AppendInteger(CC, iMaxFireArc);
 
 			return pResult;
-		}
+			}
 
 		//	Otherwise, see if we are pointing in a particular direction
 
 		else
-		{
+			{
 			int iFacingAngle = AngleMod((pDevice ? pDevice->GetRotation() : 0) + AngleMiddle(m_iMinFireArc, m_iMaxFireArc));
 			if (iFacingAngle == 0)
 				return CC.CreateNil();
 			else
 				return CC.CreateInteger(iFacingAngle);
+			}
 		}
-	}
 
 	//	Otherwise, just get the property from the weapon we're using
 
@@ -227,7 +225,7 @@ bool CAutoDefenseClass::IsDirectional(CInstalledDevice *pDevice, int *retiMinFir
 //	Returns TRUE if the autodefensedevice can turn but is not omni
 //  Copied from CWeaponClass.cpp
 
-{
+	{
 	//	If the weapon is omnidirectional then we don't need directional
 	//	calculations.
 
@@ -238,24 +236,24 @@ bool CAutoDefenseClass::IsDirectional(CInstalledDevice *pDevice, int *retiMinFir
 	//  autodefensedevice
 
 	if (pDevice)
-	{
+		{
 		//	If the device is directional then we always take the fire arc from
 		//	the device slot.
 
 		if (pDevice->IsDirectional())
-		{
+			{
 			if (retiMinFireArc)
 				*retiMinFireArc = pDevice->GetMinFireArc();
 			if (retiMaxFireArc)
 				*retiMaxFireArc = pDevice->GetMaxFireArc();
 
 			return true;
-		}
+			}
 
 		//	Otherwise, see if the autodefensedevice is directional.
 
 		else if (m_iMinFireArc != m_iMaxFireArc)
-		{
+			{
 			//	If the device points in a specific direction then we offset the
 			//	autodefensedevice's fire arc.
 
@@ -267,15 +265,15 @@ bool CAutoDefenseClass::IsDirectional(CInstalledDevice *pDevice, int *retiMinFir
 				*retiMaxFireArc = (m_iMaxFireArc + iDeviceSlotOffset) % 360;
 
 			return true;
-		}
+			}
 
 		//	Otherwise, we are not directional
 
 		else
 			return false;
-	}
+		}
 	else
-	{
+		{
 		//	Otherwise, just check the autodefensedevice
 
 		if (retiMinFireArc)
@@ -284,8 +282,8 @@ bool CAutoDefenseClass::IsDirectional(CInstalledDevice *pDevice, int *retiMinFir
 			*retiMaxFireArc = m_iMaxFireArc;
 
 		return (m_iMinFireArc != m_iMaxFireArc);
+		}
 	}
-}
 
 bool CAutoDefenseClass::IsOmniDirectional(CInstalledDevice *pDevice)
 
@@ -294,7 +292,7 @@ bool CAutoDefenseClass::IsOmniDirectional(CInstalledDevice *pDevice)
 //	Returns TRUE if the autodefensedevice is omnidirectional (not limited)
 //  Copied from CWeaponClass.cpp
 
-{
+	{
 	//	The device slot improves the autodefensedevice. If the device slot is
 	//  directional, then the autodefensedevice is directional. If the device
 	//  slot is omni directional, then the autodefensedevice is
@@ -304,7 +302,7 @@ bool CAutoDefenseClass::IsOmniDirectional(CInstalledDevice *pDevice)
 		return true;
 
 	return m_bOmnidirectional;
-}
+	}
 
 void CAutoDefenseClass::Update (CInstalledDevice *pDevice, CSpaceObject *pSource, SDeviceUpdateCtx &Ctx)
 


### PR DESCRIPTION
Note, if minFireArc and maxFirearc both are 0 in the XML, the AutoDefenseDevice will default to omnidirectional, even if `omnidirectional="false"` is present. 

This does *not* apply to item property set using objSetItemProperty; fire arcs defined using properties function exactly the same as with weapons.