### PR TITLE
Add function: unvLookup

### DIFF
--- a/Include/TSEDesign.h
+++ b/Include/TSEDesign.h
@@ -793,7 +793,6 @@ class CExtension
 		inline const CIntegerIP &GetDigest (void) const { return m_Digest; }
 		inline CExternalEntityTable *GetEntities (void) { return m_pEntities; }
 		CString GetEntityName (DWORD dwUNID) const;
-		DWORD GetEntityValue (const CString &sName) const;
 		inline const TArray<CString> &GetExternalResources (void) const { return m_Externals; }
 		inline const CString &GetFilespec (void) const { return m_sFilespec; }
 		inline EFolderTypes GetFolderType (void) const { return m_iFolderType; }
@@ -843,7 +842,6 @@ class CExtension
 		static ALERROR CreateExtensionFromRoot (const CString &sFilespec, CXMLElement *pDesc, EFolderTypes iFolder, CExternalEntityTable *pEntities, DWORD dwInheritAPIVersion, CExtension **retpExtension, CString *retsError);
 
 		void AddEntityNames (CExternalEntityTable *pEntities, TSortMap<DWORD, CString> *retMap) const;
-		void AddEntityValues (CExternalEntityTable *pEntities, TSortMap<CString, DWORD> *retMap) const;
 		void AddLibraryReference (SDesignLoadCtx &Ctx, DWORD dwUNID = 0, DWORD dwRelease = 0);
 		void AddDefaultLibraryReferences (SDesignLoadCtx &Ctx);
 		void CleanUpXML (void);
@@ -895,7 +893,6 @@ class CExtension
 
 		CAdventureDesc *m_pAdventureDesc;	//	If extAdventure, this is the descriptor
 
-		mutable TSortMap<CString, DWORD> m_EntityName2UNID;
 		mutable TSortMap<DWORD, CString> m_UNID2EntityName;
 
 		bool m_bMarked;						//	Used by CExtensionCollection for various things

--- a/Include/TSEDesign.h
+++ b/Include/TSEDesign.h
@@ -793,6 +793,7 @@ class CExtension
 		inline const CIntegerIP &GetDigest (void) const { return m_Digest; }
 		inline CExternalEntityTable *GetEntities (void) { return m_pEntities; }
 		CString GetEntityName (DWORD dwUNID) const;
+		DWORD GetEntityValue (const CString &sName) const;
 		inline const TArray<CString> &GetExternalResources (void) const { return m_Externals; }
 		inline const CString &GetFilespec (void) const { return m_sFilespec; }
 		inline EFolderTypes GetFolderType (void) const { return m_iFolderType; }
@@ -842,6 +843,7 @@ class CExtension
 		static ALERROR CreateExtensionFromRoot (const CString &sFilespec, CXMLElement *pDesc, EFolderTypes iFolder, CExternalEntityTable *pEntities, DWORD dwInheritAPIVersion, CExtension **retpExtension, CString *retsError);
 
 		void AddEntityNames (CExternalEntityTable *pEntities, TSortMap<DWORD, CString> *retMap) const;
+		void AddEntityValues (CExternalEntityTable *pEntities, TSortMap<CString, DWORD> *retMap) const;
 		void AddLibraryReference (SDesignLoadCtx &Ctx, DWORD dwUNID = 0, DWORD dwRelease = 0);
 		void AddDefaultLibraryReferences (SDesignLoadCtx &Ctx);
 		void CleanUpXML (void);
@@ -893,6 +895,7 @@ class CExtension
 
 		CAdventureDesc *m_pAdventureDesc;	//	If extAdventure, this is the descriptor
 
+		mutable TSortMap<CString, DWORD> m_EntityName2UNID;
 		mutable TSortMap<DWORD, CString> m_UNID2EntityName;
 
 		bool m_bMarked;						//	Used by CExtensionCollection for various things
@@ -954,6 +957,8 @@ class CExtensionCollection
 		bool FindExtension (DWORD dwUNID, DWORD dwRelease, CExtension::EFolderTypes iFolder, CExtension **retpExtension = NULL);
 		void FreeDeleted (void);
 		CExtension *GetBase (void) const { return m_pBase; }
+		CString GetEntityName (DWORD dwUNID);
+		DWORD GetEntityValue (const CString &sName);
 		CString GetExternalResourceFilespec (CExtension *pExtension, const CString &sFilename) const;
 		EGameTypes GetGame (void) const { return m_iGame; }
 		bool GetRequiredResources (TArray<CString> *retFilespecs);

--- a/TSE/CCExtensions.cpp
+++ b/TSE/CCExtensions.cpp
@@ -510,7 +510,7 @@ ICCItem *fnDesignFind (CEvalContext *pEvalCtx, ICCItem *pArgs, DWORD dwData);
 #define FN_UNIVERSE_FIND_OBJ			6
 #define FN_UNIVERSE_GET_ELAPSED_GAME_TIME	7
 #define FN_UNIVERSE_SET_OBJECT_KNOWN	8
-#define FN_UNIVERSE_LOOKUP				9
+#define FN_UNIVERSE_ENTITY				9
 
 ICCItem *fnUniverseGet (CEvalContext *pEvalCtx, ICCItem *pArgs, DWORD dwData);
 
@@ -3174,9 +3174,9 @@ static PRIMITIVEPROCDEF g_Extensions[] =
 			"(unvUNID string) -> (unid 'itemtype name) or (unid 'shipclass name)",
 			"s",	0,	},
 
-		{	"unvLookup",						fnUniverseGet,	FN_UNIVERSE_LOOKUP,
-			"(unvLookup entity) -> unid\n"
-			"(unvLookup unid) -> entity",
+		{	"unvEntity",						fnUniverseGet,	FN_UNIVERSE_ENTITY,
+			"(unvEntity entity) -> unid\n"
+			"(unvEntity unid) -> entity",
 			"v",	0,	},
 
 		//	XML functions
@@ -13267,7 +13267,7 @@ ICCItem *fnUniverseGet (CEvalContext *pEvalCtx, ICCItem *pArgs, DWORD dwData)
 			return pCC->Link(sData, 0, NULL);
 			}
 
-		case FN_UNIVERSE_LOOKUP:
+		case FN_UNIVERSE_ENTITY:
 			{
 			//	If we have a UNID, then find the matching entity
 			//	Otherwise, we have an entity so we find the matching UNID

--- a/TSE/CCExtensions.cpp
+++ b/TSE/CCExtensions.cpp
@@ -510,6 +510,7 @@ ICCItem *fnDesignFind (CEvalContext *pEvalCtx, ICCItem *pArgs, DWORD dwData);
 #define FN_UNIVERSE_FIND_OBJ			6
 #define FN_UNIVERSE_GET_ELAPSED_GAME_TIME	7
 #define FN_UNIVERSE_SET_OBJECT_KNOWN	8
+#define FN_UNIVERSE_LOOKUP				9
 
 ICCItem *fnUniverseGet (CEvalContext *pEvalCtx, ICCItem *pArgs, DWORD dwData);
 
@@ -3172,6 +3173,11 @@ static PRIMITIVEPROCDEF g_Extensions[] =
 		{	"unvUNID",						fnUniverseGet,	FN_UNIVERSE_UNID,
 			"(unvUNID string) -> (unid 'itemtype name) or (unid 'shipclass name)",
 			"s",	0,	},
+
+		{	"unvLookup",						fnUniverseGet,	FN_UNIVERSE_LOOKUP,
+			"(unvLookup entity) -> unid\n"
+			"(unvLookup unid) -> entity",
+			"v",	0,	},
 
 		//	XML functions
 		//	-------------
@@ -13259,6 +13265,33 @@ ICCItem *fnUniverseGet (CEvalContext *pEvalCtx, ICCItem *pArgs, DWORD dwData)
 			//	Result
 
 			return pCC->Link(sData, 0, NULL);
+			}
+
+		case FN_UNIVERSE_LOOKUP:
+			{
+			//	If we have a UNID, then find the matching entity
+			//	Otherwise, we have an entity so we find the matching UNID
+			CString sName;
+			DWORD dwUNID;
+			if (pArgs->GetElement(0)->IsInteger())
+				{
+				dwUNID = pArgs->GetElement(0)->GetIntegerValue();
+				sName = g_pUniverse->GetExtensionCollection().GetEntityName(dwUNID);
+				if (!sName.IsBlank())
+					return pCC->CreateString(sName);
+				else
+					return pCC->CreateNil();
+				}
+			else
+				{
+				sName = pArgs->GetElement(0)->GetStringValue();
+				dwUNID = g_pUniverse->GetExtensionCollection().GetEntityValue(sName);
+				if (dwUNID)
+					return pCC->CreateInteger(dwUNID);
+				else
+					return pCC->CreateNil();
+				}
+
 			}
 
 		case FN_UNIVERSE_REAL_DATE:

--- a/TSE/CExtension.cpp
+++ b/TSE/CExtension.cpp
@@ -139,6 +139,27 @@ void CExtension::AddEntityNames (CExternalEntityTable *pEntities, TSortMap<DWORD
 		}
 	}
 
+void CExtension::AddEntityValues (CExternalEntityTable *pEntities, TSortMap<CString, DWORD> *retMap) const
+
+//	AddEntityValues
+//
+//	Adds entity values to the given map
+
+	{
+	int i;
+
+	for (i = 0; i < pEntities->GetCount(); i++)
+		{
+		CString sEntity, sValue;
+		pEntities->GetEntity(i, &sEntity, &sValue);
+
+		//	Add to the list
+
+		DWORD dwUNID = strToInt(sValue, 0);
+		retMap->SetAt(sEntity, dwUNID);
+		}
+	}
+
 void CExtension::AddLibraryReference (SDesignLoadCtx &Ctx, DWORD dwUNID, DWORD dwRelease)
 
 //	AddLibraryReference
@@ -900,6 +921,32 @@ CString CExtension::GetEntityName (DWORD dwUNID) const
 
 	return *pName;
 	}
+
+DWORD CExtension::GetEntityValue (const CString &sName) const
+
+//	GetEntityValue
+//
+//	Returns the UNID of the given entity name (or NULL_STR if we don't have it).
+
+{
+	//	Must have entities
+
+	if (m_pEntities == NULL)
+		return NULL;
+
+	//	If we don't yet have it, create a lookup
+
+	if (m_EntityName2UNID.GetCount() == 0)
+		AddEntityValues(m_pEntities, &m_EntityName2UNID);
+
+	//	Return it
+
+	DWORD *pUNID = m_EntityName2UNID.GetAt(sName);
+	if (pUNID == NULL)
+		return NULL;
+
+	return *pUNID;
+}
 
 DWORDLONG CExtension::GetXMLMemoryUsage (void) const
 

--- a/TSE/CExtension.cpp
+++ b/TSE/CExtension.cpp
@@ -139,27 +139,6 @@ void CExtension::AddEntityNames (CExternalEntityTable *pEntities, TSortMap<DWORD
 		}
 	}
 
-void CExtension::AddEntityValues (CExternalEntityTable *pEntities, TSortMap<CString, DWORD> *retMap) const
-
-//	AddEntityValues
-//
-//	Adds entity values to the given map
-
-	{
-	int i;
-
-	for (i = 0; i < pEntities->GetCount(); i++)
-		{
-		CString sEntity, sValue;
-		pEntities->GetEntity(i, &sEntity, &sValue);
-
-		//	Add to the list
-
-		DWORD dwUNID = strToInt(sValue, 0);
-		retMap->SetAt(sEntity, dwUNID);
-		}
-	}
-
 void CExtension::AddLibraryReference (SDesignLoadCtx &Ctx, DWORD dwUNID, DWORD dwRelease)
 
 //	AddLibraryReference
@@ -921,32 +900,6 @@ CString CExtension::GetEntityName (DWORD dwUNID) const
 
 	return *pName;
 	}
-
-DWORD CExtension::GetEntityValue (const CString &sName) const
-
-//	GetEntityValue
-//
-//	Returns the UNID of the given entity name (or NULL_STR if we don't have it).
-
-{
-	//	Must have entities
-
-	if (m_pEntities == NULL)
-		return NULL;
-
-	//	If we don't yet have it, create a lookup
-
-	if (m_EntityName2UNID.GetCount() == 0)
-		AddEntityValues(m_pEntities, &m_EntityName2UNID);
-
-	//	Return it
-
-	DWORD *pUNID = m_EntityName2UNID.GetAt(sName);
-	if (pUNID == NULL)
-		return NULL;
-
-	return *pUNID;
-}
 
 DWORDLONG CExtension::GetXMLMemoryUsage (void) const
 

--- a/TSE/CExtensionCollection.cpp
+++ b/TSE/CExtensionCollection.cpp
@@ -1128,6 +1128,48 @@ void CExtensionCollection::FreeDeleted (void)
 	DEBUG_CATCH
 	}
 
+CString CExtensionCollection::GetEntityName (DWORD dwUNID)
+
+//	GetEntityName
+//
+//	Look up the name of an entity by its value
+
+	{
+	CString sName;
+
+	//	Look through all of our extensions
+
+	for (int i = 0; i < m_Extensions.GetCount(); i++)
+		{
+		sName = m_Extensions[i]->GetEntityName(dwUNID);
+		
+		if (!sName.IsBlank())
+			return sName;
+		}
+	return NULL_STR;
+	}
+
+DWORD CExtensionCollection::GetEntityValue (const CString &sName)
+
+//	GetEntityValue
+//
+//	Look up the value of an entity by its name
+
+	{
+	DWORD dwUNID;
+
+	//	Look through all of our extensions
+
+	for (int i = 0; i < m_Extensions.GetCount(); i++)
+		{
+		dwUNID = m_Extensions[i]->GetEntityValue(sName);
+		
+		if (dwUNID)
+			return dwUNID;
+		}
+	return NULL;
+	}
+
 CString CExtensionCollection::GetExternalResourceFilespec (CExtension *pExtension, const CString &sFilename) const
 
 //	GetExternalResourceFilespec

--- a/TSE/CExtensionCollection.cpp
+++ b/TSE/CExtensionCollection.cpp
@@ -1162,8 +1162,7 @@ DWORD CExtensionCollection::GetEntityValue (const CString &sName)
 
 	for (int i = 0; i < m_Extensions.GetCount(); i++)
 		{
-		dwUNID = m_Extensions[i]->GetEntityValue(sName);
-		
+		dwUNID = strToInt(m_Extensions[i]->GetEntities()->ResolveExternalEntity(sName), 0);
 		if (dwUNID)
 			return dwUNID;
 		}


### PR DESCRIPTION
`(unvLookup entity) -> unid`
`(unvLookup unid) -> entity`

This function allows you to lookup a unid by its entity name. For instance, `(unvLookup 'svPlayer) -> 4097`. See the image below for more examples

![unvlookup](https://user-images.githubusercontent.com/15680274/31521348-0498aa58-af5e-11e7-85f3-0d6c72ec744b.png)
