### PR TITLE
Added <OnArmorConsumePower> event to armor.

### DIFF
--- a/Include/TSEArmor.h
+++ b/Include/TSEArmor.h
@@ -299,7 +299,7 @@ class CInstalledArmor
 	private:
 		CItem *m_pItem;								//	Item
 		CArmorClass *m_pArmorClass;					//	Armor class used
-		int m_iCustomPowerResults;					//	Power generated/consumed, determined by OnArmorConsumePower
+		int m_iCustomPowerResults = 0;				//	Power generated/consumed, determined by OnArmorConsumePower
 		int m_iHitPoints;							//	Hit points left
 		TSharedPtr<CItemEnhancementStack> m_pEnhancements;		//	List of enhancements (may be NULL)
 

--- a/Include/TSEArmor.h
+++ b/Include/TSEArmor.h
@@ -168,7 +168,7 @@ class CArmorClass
         const SScalableStats &GetScaledStats (CItemCtx &ItemCtx) const;
 		int FireGetMaxHP (CItemCtx &ItemCtx, int iMaxHP) const;
 		void FireOnArmorDamage (CItemCtx &ItemCtx, SDamageCtx &Ctx);
-		bool UpdateCustom (CItemCtx &ItemCtx, const SScalableStats &Stats, int iTick);
+		int UpdateCustom(CInstalledArmor *pArmor, CSpaceObject *pSource, SEventHandlerDesc Event);
 		bool UpdateDecay (CItemCtx &ItemCtx, const SScalableStats &Stats, int iTick);
 		bool UpdateDistribute (CItemCtx &ItemCtx, const SScalableStats &Stats, int iTick);
 
@@ -272,7 +272,6 @@ class CInstalledArmor
 		void FinishInstall (CSpaceObject *pSource);
 		inline int GetCharges (CSpaceObject *pSource) { return (m_pItem ? m_pItem->GetCharges() : 0); }
 		inline CArmorClass *GetClass (void) const { return m_pArmorClass; }
-		inline int GetCustomPowerResults (void) const { return m_iCustomPowerResults; }
 		inline int GetDamageEffectiveness (CSpaceObject *pAttacker, CInstalledDevice *pWeapon);
 		inline TSharedPtr<CItemEnhancementStack> GetEnhancementStack (void) const { return m_pEnhancements; }
 		inline int GetHitPoints (void) const { return m_iHitPoints; }
@@ -288,7 +287,6 @@ class CInstalledArmor
 		inline bool IsPrime (void) const { return (m_fPrimeSegment ? true : false); }
 		void SetComplete (CSpaceObject *pSource, bool bComplete = true);
 		inline void SetConsumePower (bool bValue = true) { m_fConsumePower = bValue; }
-		inline void SetCustomPowerResults (int iValue) { m_iCustomPowerResults = iValue; }
 		void SetEnhancements (CSpaceObject *pSource, const TSharedPtr<CItemEnhancementStack> &pStack);
 		inline void SetPrime (CSpaceObject *pSource, bool bPrime = true) { m_fPrimeSegment = bPrime; }
 		inline void SetHitPoints (int iHP) { m_iHitPoints = iHP; }
@@ -299,7 +297,6 @@ class CInstalledArmor
 	private:
 		CItem *m_pItem;								//	Item
 		CArmorClass *m_pArmorClass;					//	Armor class used
-		int m_iCustomPowerResults = 0;				//	Power generated/consumed, determined by OnArmorConsumePower
 		int m_iHitPoints;							//	Hit points left
 		TSharedPtr<CItemEnhancementStack> m_pEnhancements;		//	List of enhancements (may be NULL)
 

--- a/Include/TSEArmor.h
+++ b/Include/TSEArmor.h
@@ -22,8 +22,9 @@ class CArmorClass
 			{
 			evtGetMaxHP					= 0,
 			evtOnArmorDamage			= 1,
+			evtOnArmorConsumePower		= 2,
 
-			evtCount					= 2,
+			evtCount					= 3,
 			};
 
 		struct SBalance
@@ -167,6 +168,7 @@ class CArmorClass
         const SScalableStats &GetScaledStats (CItemCtx &ItemCtx) const;
 		int FireGetMaxHP (CItemCtx &ItemCtx, int iMaxHP) const;
 		void FireOnArmorDamage (CItemCtx &ItemCtx, SDamageCtx &Ctx);
+		bool UpdateCustom (CItemCtx &ItemCtx, const SScalableStats &Stats, int iTick);
 		bool UpdateDecay (CItemCtx &ItemCtx, const SScalableStats &Stats, int iTick);
 		bool UpdateDistribute (CItemCtx &ItemCtx, const SScalableStats &Stats, int iTick);
 
@@ -192,6 +194,7 @@ class CArmorClass
 		DWORD m_fDisintegrationImmune:1;		//	TRUE if immune to disintegration
 		DWORD m_fShatterImmune:1;				//	TRUE if immune to shatter
 		DWORD m_fChargeDecay:1;					//	If TRUE, we decay while we have charges left
+		DWORD m_fCustomConsumePower : 1;		//  If TRUE, we fire a custom event, and consume power if it returns True
 		DWORD m_fSpare6:1;
 		DWORD m_fSpare7:1;
 		DWORD m_fSpare8:1;
@@ -269,6 +272,7 @@ class CInstalledArmor
 		void FinishInstall (CSpaceObject *pSource);
 		inline int GetCharges (CSpaceObject *pSource) { return (m_pItem ? m_pItem->GetCharges() : 0); }
 		inline CArmorClass *GetClass (void) const { return m_pArmorClass; }
+		inline int GetCustomPowerResults (void) const { return m_iCustomPowerResults; }
 		inline int GetDamageEffectiveness (CSpaceObject *pAttacker, CInstalledDevice *pWeapon);
 		inline TSharedPtr<CItemEnhancementStack> GetEnhancementStack (void) const { return m_pEnhancements; }
 		inline int GetHitPoints (void) const { return m_iHitPoints; }
@@ -284,6 +288,7 @@ class CInstalledArmor
 		inline bool IsPrime (void) const { return (m_fPrimeSegment ? true : false); }
 		void SetComplete (CSpaceObject *pSource, bool bComplete = true);
 		inline void SetConsumePower (bool bValue = true) { m_fConsumePower = bValue; }
+		inline void SetCustomPowerResults (int iValue) { m_iCustomPowerResults = iValue; }
 		void SetEnhancements (CSpaceObject *pSource, const TSharedPtr<CItemEnhancementStack> &pStack);
 		inline void SetPrime (CSpaceObject *pSource, bool bPrime = true) { m_fPrimeSegment = bPrime; }
 		inline void SetHitPoints (int iHP) { m_iHitPoints = iHP; }
@@ -294,6 +299,7 @@ class CInstalledArmor
 	private:
 		CItem *m_pItem;								//	Item
 		CArmorClass *m_pArmorClass;					//	Armor class used
+		int m_iCustomPowerResults;					//	Power generated/consumed, determined by OnArmorConsumePower
 		int m_iHitPoints;							//	Hit points left
 		TSharedPtr<CItemEnhancementStack> m_pEnhancements;		//	List of enhancements (may be NULL)
 

--- a/TSE/CArmorClass.cpp
+++ b/TSE/CArmorClass.cpp
@@ -2417,8 +2417,7 @@ bool CArmorClass::UpdateCustom (CItemCtx &ItemCtx, const SScalableStats &Stats, 
 		}
 
 	//	We've modified the armor
-	//
-	//	LATER: Add new class property to allow users to specify how much power to consume/generate.
+
 	if (iResult)
 		pArmor->SetConsumePower(true);
 	return iResult;

--- a/TSE/CArmorClass.cpp
+++ b/TSE/CArmorClass.cpp
@@ -1261,7 +1261,7 @@ int CArmorClass::CalcPowerUsed (SUpdateCtx &Ctx, CSpaceObject *pSource, CInstall
 
 	if (pArmor->GetCustomPowerResults() > 0)
 		{
-		iTotalPower += pArmor->GetCustomPowerResults();
+		iTotalPower = pArmor->GetCustomPowerResults();
 		}
 
 	//	Done


### PR DESCRIPTION
This event allows users to specify custom behavior on armor that causes
power consumption, as well as customized armor power usage. To enable
this, set the armor's "useOnArmorConsumePower" attribute to True.

If the attribute is enabled, then power equal to powerUse will be consumed
if the event returns True. If the returned value is an integer, that
amount of power will be consumed.

This allows users to have custom armor segments that do more things besides
regeneration/distribution/other engine-specified functions. For instance, an user
could create an armor segment that uses power to increase the shield's regeneration
rate, or an armor segment that uses power to leech armor HP from enemy ships (and
does not consume power when shields are full/not enabled/not installed or HP is full/
no enemies are nearby respectively).