### PR TITLE
Device damage/disrupt immunity

### DIFF
--- a/Include/TSEDeviceClassesImpl.h
+++ b/Include/TSEDeviceClassesImpl.h
@@ -64,6 +64,7 @@ class CCargoSpaceClass : public CDeviceClass
 
 		virtual bool CanBeDamaged (void) override { return false; }
 		virtual bool CanBeDisabled (CItemCtx &Ctx) override { return false; }
+		virtual bool CanBeDisrupted (void) override { return false; }
 		virtual bool FindDataField (const CString &sField, CString *retsValue) override;
 		virtual const CCargoDesc *GetCargoDesc (CItemCtx &Ctx) const override { return GetDesc(Ctx); }
 		virtual ItemCategories GetImplCategory (void) const override { return itemcatCargoHold; }

--- a/Include/TSEDevices.h
+++ b/Include/TSEDevices.h
@@ -201,8 +201,9 @@ class CDeviceClass
 		virtual CWeaponClass *AsWeaponClass (void) { return NULL; }
 		virtual int CalcFireSolution (CInstalledDevice *pDevice, CSpaceObject *pSource, CSpaceObject *pTarget) { return -1; }
 		virtual int CalcPowerUsed (SUpdateCtx &Ctx, CInstalledDevice *pDevice, CSpaceObject *pSource) { return 0; }
-		virtual bool CanBeDamaged (void) { return true; }
+		virtual bool CanBeDamaged (void) { return !m_bDeviceDamageImmune; }
 		virtual bool CanBeDisabled (CItemCtx &Ctx) { return (GetPowerRating(Ctx) != 0); }
+		virtual bool CanBeDisrupted(void) { return !m_bDeviceDisruptImmune; }
 		virtual bool CanHitFriends (void) { return true; }
 		virtual bool CanRotate (CItemCtx &Ctx, int *retiMinFireArc = NULL, int *retiMaxFireArc = NULL) const { return false; }
 		virtual void Deplete (CInstalledDevice *pDevice, CSpaceObject *pSource) { }
@@ -285,6 +286,9 @@ class CDeviceClass
 		CItemType *m_pItemType;					//	Item for device
 		int m_iSlots;							//	Number of device slots required
 		ItemCategories m_iSlotCategory;			//	Count as this category (for device slot purposes)
+
+		bool m_bDeviceDamageImmune;				//	Prevents this device from being damaged by ion effects. Only applies to devices that can be damaged in the first place. Default: false
+		bool m_bDeviceDisruptImmune;			//	Prevents this device from being disrupted by ion effects. Only applies to devices that can be damaged in the first place. Default: false
 
 		COverlayTypeRef m_pOverlayType;			//	Associated overlay (may be NULL)
 
@@ -477,6 +481,7 @@ class CInstalledDevice
 		int CalcPowerUsed (SUpdateCtx &Ctx, CSpaceObject *pSource);
 		inline bool CanBeDamaged (void) { return m_pClass->CanBeDamaged(); }
 		inline bool CanBeDisabled (CItemCtx &Ctx) { return m_pClass->CanBeDisabled(Ctx); }
+		inline bool CanBeDisrupted (void) { return m_pClass->CanBeDisrupted(); }
 		inline bool CanHitFriends (void) { return m_pClass->CanHitFriends(); }
 		inline bool CanRotate (CItemCtx &Ctx) const { return m_pClass->CanRotate(Ctx); }
 		inline void Deplete (CSpaceObject *pSource) { m_pClass->Deplete(this, pSource); }

--- a/TSE/CItemType.cpp
+++ b/TSE/CItemType.cpp
@@ -117,6 +117,7 @@
 #define PROPERTY_WEAPON_TYPES					CONSTLIT("weaponTypes")
 
 #define SPECIAL_CAN_BE_DAMAGED					CONSTLIT("canBeDamaged:")
+#define SPECIAL_CAN_BE_DISRUPTED				CONSTLIT("canBeDisrupted:")
 #define SPECIAL_DAMAGE_TYPE						CONSTLIT("damageType:")
 #define SPECIAL_HAS_COMPONENTS					CONSTLIT("hasComponents:")
 #define SPECIAL_IS_LAUNCHER						CONSTLIT("isLauncher:")
@@ -1765,6 +1766,18 @@ bool CItemType::OnHasSpecialAttribute (const CString &sAttrib) const
 		CDeviceClass *pDevice;
 		if (pDevice = GetDeviceClass())
 			return (pDevice->CanBeDamaged() == bValue);
+		else if (IsArmor())
+			return (true == bValue);
+		else
+			return (false == bValue);
+		}
+	else if (strStartsWith(sAttrib, SPECIAL_CAN_BE_DISRUPTED))
+		{
+		bool bValue = strEquals(strSubString(sAttrib, SPECIAL_CAN_BE_DISRUPTED.GetLength(), -1), SPECIAL_TRUE);
+
+		CDeviceClass *pDevice;
+		if (pDevice = GetDeviceClass())
+			return (pDevice->CanBeDisrupted() == bValue);
 		else if (IsArmor())
 			return (true == bValue);
 		else

--- a/TSE/CShip.cpp
+++ b/TSE/CShip.cpp
@@ -4940,7 +4940,7 @@ void CShip::OnHitByDeviceDisruptDamage (DWORD dwDuration)
 	//	We pick a random installed device
 
 	CItemCriteria Criteria;
-	CItem::ParseCriteria(CONSTLIT("dI +canBeDamaged:true;"), &Criteria);
+	CItem::ParseCriteria(CONSTLIT("dI +canBeDisrupted:true;"), &Criteria);
 
 	CItemListManipulator ItemList(GetItemList());
 	SetCursorAtRandomItem(ItemList, Criteria);
@@ -4958,10 +4958,11 @@ void CShip::OnHitByDeviceDisruptDamage (DWORD dwDuration)
 			NULL;
 
 		//	Otherwise, if the device is already disrupted, then there is
-		//	a chance that it will be damaged
+		//	a chance that it will be damaged (if possible)
 
 		else if (pDevice->IsDisrupted()
-				&& pDevice->GetDisruptedDuration() > MAX_DISRUPT_TIME_BEFORE_DAMAGE)
+				&& pDevice->GetDisruptedDuration() > MAX_DISRUPT_TIME_BEFORE_DAMAGE
+				&& pDevice->CanBeDamaged())
 			{
 			DamageItem(ItemList);
 			OnDeviceStatus(pDevice, CDeviceClass::failDamagedByDisruption);

--- a/TSE/Devices.cpp
+++ b/TSE/Devices.cpp
@@ -9,6 +9,8 @@
 
 #define CATEGORY_ATTRIB							CONSTLIT("category")
 #define CRITERIA_ATTRIB							CONSTLIT("criteria")
+#define DEVICE_DAMAGE_IMMUNE_ATTRIB				CONSTLIT("deviceDamageImmune")
+#define DEVICE_DISRUPT_IMMUNE_ATTRIB			CONSTLIT("deviceDisruptImmune")
 #define DEVICE_SLOT_CATEGORY_ATTRIB				CONSTLIT("deviceSlotCategory")
 #define DEVICE_SLOTS_ATTRIB						CONSTLIT("deviceSlots")
 #define ENHANCEMENT_ATTRIB						CONSTLIT("enhancement")
@@ -30,7 +32,9 @@
 #define LINKED_FIRE_ENEMY						CONSTLIT("whenInFireArc")
 #define LINKED_FIRE_TARGET						CONSTLIT("targetInRange")
 
+#define PROPERTY_CAN_BE_DAMAGED					CONSTLIT("canBeDamaged")
 #define PROPERTY_CAN_BE_DISABLED				CONSTLIT("canBeDisabled")
+#define PROPERTY_CAN_BE_DISRUPTED				CONSTLIT("canBeDisrupted")
 #define PROPERTY_CAPACITOR      				CONSTLIT("capacitor")
 #define PROPERTY_ENABLED						CONSTLIT("enabled")
 #define PROPERTY_EXTERNAL						CONSTLIT("external")
@@ -341,6 +345,23 @@ ALERROR CDeviceClass::InitDeviceFromXML (SDesignLoadCtx &Ctx, CXMLElement *pDesc
 	else
 		m_iSlots = 1;
 
+	//	Is this device immune to damage and disrupt?
+	//	Note: We assume that damageable and disruptable do not mean the same thing.
+	//	There could be a device that is immune to disrupt but vulnerable to other damaging effects.
+	//	There could also be a device that is disruptable but not damageable.
+
+	bool bDeviceDamageImmune;
+	if (pDesc->FindAttributeBool(DEVICE_DAMAGE_IMMUNE_ATTRIB, &bDeviceDamageImmune))
+		m_bDeviceDamageImmune = bDeviceDamageImmune;
+	else
+		m_bDeviceDamageImmune = false;
+
+	bool bDeviceDisruptImmune;
+	if (pDesc->FindAttributeBool(DEVICE_DISRUPT_IMMUNE_ATTRIB, &bDeviceDisruptImmune))
+		m_bDeviceDisruptImmune = bDeviceDisruptImmune;
+	else
+		m_bDeviceDisruptImmune = false;
+
 	//	Slot type
 
 	CString sSlotType;
@@ -446,9 +467,12 @@ ICCItem *CDeviceClass::FindItemProperty (CItemCtx &Ctx, const CString &sName)
 
 	//	Get the property
 
-    if (strEquals(sName, PROPERTY_CAN_BE_DISABLED))
+	if (strEquals(sName, PROPERTY_CAN_BE_DAMAGED))
+		return (pDevice ? CC.CreateBool(pDevice->CanBeDamaged()) : CC.CreateBool(CanBeDamaged()));
+    else if (strEquals(sName, PROPERTY_CAN_BE_DISABLED))
         return (pDevice ? CC.CreateBool(pDevice->CanBeDisabled(Ctx)) : CC.CreateBool(CanBeDisabled(Ctx)));
-
+	else if (strEquals(sName, PROPERTY_CAN_BE_DISRUPTED))
+		return (pDevice ? CC.CreateBool(pDevice->CanBeDisrupted()) : CC.CreateBool(CanBeDisrupted()));
     else if (strEquals(sName, PROPERTY_CAPACITOR))
         {
         CSpaceObject *pSource = Ctx.GetSource();


### PR DESCRIPTION
http://ministry.kronosaur.com/record.hexm?id=73309

Added device attributes: deviceDamageImmune, deviceDisruptImmune
deviceDamageImmune: Prevents a device from being damaged (even if disrupted); only works if the device can be damaged by default
deviceDisruptImmune: Prevents a device from being disrupted; only works if the device can be disrupted by default.

Added device properties: canBeDamaged, canBeDisrupted