### PR TITLE
Fixed objSetItemProperty with 'capacitor for misc devices (e.g. jumpdrive)

### DIFF
--- a/TSE/CMiscellaneousClass.cpp
+++ b/TSE/CMiscellaneousClass.cpp
@@ -205,7 +205,7 @@ bool CMiscellaneousClass::SetCounter (CInstalledDevice *pDevice, CSpaceObject *p
 	int iActivateDelay = GetActivateDelay(pDevice, pSource);
     int iTimeLeft = Max(0, Min((100 - iLevel) * iActivateDelay / 100, iActivateDelay));
 
-    pDevice->SetActivateDelay(iTimeLeft);
+    pDevice->SetTimeUntilReady(iTimeLeft);
 	pSource->OnComponentChanged(comDeviceCounter);
 
     return true;


### PR DESCRIPTION
For some reason, pDevice->SetActivateDelay() doesn't actually change the activate delay for misc devices, while pDevice->SetTimeUntilReady() does.