### PR TITLE
Install armor before devices in CShip::CreateFromClass

### DIFF
--- a/TSE/CShip.cpp
+++ b/TSE/CShip.cpp
@@ -1495,6 +1495,15 @@ ALERROR CShip::CreateFromClass (CSystem *pSystem,
 	if (error = pShip->CreateRandomItems(pClass->GetRandomItemTable(), pSystem))
 		return error;
 
+	//	Initialize the armor from the class
+
+    pShip->m_Armor.Install(pShip, pClass->GetArmorDesc(), true);
+
+	//	Remember if we need to call OnInstall for this item
+	//	(All armor needs this)
+
+	bInstallItemEvent = true;
+
 	//	Devices
 
 	for (i = 0; i < devNamesCount; i++)
@@ -1586,15 +1595,6 @@ ALERROR CShip::CreateFromClass (CSystem *pSystem,
 		delete pShip;
 		return error;
 		}
-
-	//	Initialize the armor from the class
-
-    pShip->m_Armor.Install(pShip, pClass->GetArmorDesc(), true);
-
-	//	Remember if we need to call OnInstall for this item
-	//	(All armor needs this)
-
-	bInstallItemEvent = true;
 
 	pShip->OnComponentChanged(comCargo);
 	pShip->CalcArmorBonus();

--- a/TSE/CShip.cpp
+++ b/TSE/CShip.cpp
@@ -1495,6 +1495,12 @@ ALERROR CShip::CreateFromClass (CSystem *pSystem,
 	if (error = pShip->CreateRandomItems(pClass->GetRandomItemTable(), pSystem))
 		return error;
 
+	//	See if we need to call an OnInstall event. For the player
+	//	we always do it because we track install statistics.
+	//	For other ships, we only call it if an item has OnInstall code
+
+	bool bInstallItemEvent = pController->IsPlayer();
+
 	//	Initialize the armor from the class
 
     pShip->m_Armor.Install(pShip, pClass->GetArmorDesc(), true);
@@ -1514,12 +1520,6 @@ ALERROR CShip::CreateFromClass (CSystem *pSystem,
 
 	pShip->m_iDeviceCount = Max(Devices.GetCount(), pClass->GetMaxDevices());
 	pShip->m_Devices = new CInstalledDevice [pShip->m_iDeviceCount];
-
-	//	See if we need to call an OnInstall event. For the player
-	//	we always do it because we track install statistics.
-	//	For other ships, we only call it if an item has OnInstall code
-
-	bool bInstallItemEvent = pController->IsPlayer();
 
 	CItemListManipulator ShipItems(pShip->GetItemList());
 	for (i = 0; i < Devices.GetCount(); i++)

--- a/TSE/CShip.cpp
+++ b/TSE/CShip.cpp
@@ -1503,7 +1503,7 @@ ALERROR CShip::CreateFromClass (CSystem *pSystem,
 
 	//	Initialize the armor from the class
 
-    pShip->m_Armor.Install(pShip, pClass->GetArmorDesc(), true);
+	pShip->m_Armor.Install(pShip, pClass->GetArmorDesc(), true);
 
 	//	Remember if we need to call OnInstall for this item
 	//	(All armor needs this)


### PR DESCRIPTION
This should fix the issue where ships start with shields less than full if their shield's strength depends on installed armor.

https://ministry.kronosaur.com/record.hexm?id=75013
https://ministry.kronosaur.com/record.hexm?id=54939