### PR TITLE
Option to keep completed non-player missions

### DIFF
--- a/Include/TSEMissionType.h
+++ b/Include/TSEMissionType.h
@@ -11,6 +11,7 @@ class CMissionType : public CDesignType
 		inline bool CanBeDeclined (void) const { return !m_fNoDecline; }
 		inline bool CanBeDeleted (void) const { return m_fAllowDelete; }
 		inline bool CanBeEncountered (void) const { return (m_iMaxAppearing == -1 || m_iAccepted < m_iMaxAppearing); }
+		inline bool CleanNonPlayer(void) const { return !m_fRecordNonPlayer; }
 		inline bool CloseIfOutOfSystem (void) const { return m_fCloseIfOutOfSystem; }
 		inline bool FailureWhenOwnerDestroyed (void) const { return !m_fNoFailureOnOwnerDestroyed; }
 		inline bool FailureWhenOutOfSystem (void) const { return (m_iFailIfOutOfSystem != -1); }
@@ -68,7 +69,7 @@ class CMissionType : public CDesignType
 		DWORD m_fForceUndockAfterDebrief:1;	//	If TRUE, default mission screen undocks after debrief
 		DWORD m_fAllowDelete:1;				//	If TRUE, player can delete mission
 		DWORD m_fNoDecline:1;				//	If TRUE, mission cannot be declined once offered.
-		DWORD m_fSpare8:1;
+		DWORD m_fRecordNonPlayer:1;			//	If TRUE, non-player missions will not be deleted after completion
 
 		DWORD m_dwSpare:24;
 	};

--- a/Include/TSEMissions.h
+++ b/Include/TSEMissions.h
@@ -43,6 +43,7 @@ class CMission : public CSpaceObject
 							   CMission **retpMission,
 							   CString *retsError);
 		void FireCustomEvent (const CString &sEvent, ICCItem *pData);
+		inline bool CleanNonPlayer (void) const { return m_pType->CleanNonPlayer(); }
 		inline DWORD GetAcceptedOn (void) const { return m_dwAcceptedOn; }
 		inline int GetPriority (void) const { return m_pType->GetPriority(); }
 		inline bool IsActive (void) const { return (m_iStatus == statusAccepted || (!m_fDebriefed && (m_iStatus == statusPlayerSuccess || m_iStatus == statusPlayerFailure))); }

--- a/TSE/CMissionType.cpp
+++ b/TSE/CMissionType.cpp
@@ -17,6 +17,7 @@
 #define NO_FAILURE_ON_OWNER_DESTROYED_ATTRIB	CONSTLIT("noFailureOnOwnerDestroyed")
 #define NO_STATS_ATTRIB							CONSTLIT("noStats")
 #define PRIORITY_ATTRIB							CONSTLIT("priority")
+#define RECORD_NON_PLAYER_ATTRIB				CONSTLIT("recordNonPlayer")
 
 #define FIELD_LEVEL								CONSTLIT("level")
 #define FIELD_MAX_LEVEL							CONSTLIT("maxLevel")
@@ -70,6 +71,7 @@ ALERROR CMissionType::OnCreateFromXML (SDesignLoadCtx &Ctx, CXMLElement *pDesc)
 	m_iPriority = pDesc->GetAttributeIntegerBounded(PRIORITY_ATTRIB, 0, -1, 1);
 	m_iExpireTime = pDesc->GetAttributeIntegerBounded(EXPIRE_TIME_ATTRIB, 1, -1, -1);
 	m_iFailIfOutOfSystem = pDesc->GetAttributeIntegerBounded(FAILURE_AFTER_OUT_OF_SYSTEM_ATTRIB, 0, -1, -1);
+	m_fRecordNonPlayer = pDesc->GetAttributeBool(RECORD_NON_PLAYER_ATTRIB);
 	m_fNoFailureOnOwnerDestroyed = pDesc->GetAttributeBool(NO_FAILURE_ON_OWNER_DESTROYED_ATTRIB);
 	m_fNoDebrief = pDesc->GetAttributeBool(NO_DEBRIEF_ATTRIB);
 	m_fNoDecline = pDesc->GetAttributeBool(NO_DECLINE_ATTRIB);

--- a/TSE/CUniverse.cpp
+++ b/TSE/CUniverse.cpp
@@ -2642,7 +2642,7 @@ void CUniverse::SetNewSystem (CSystem *pSystem, CSpaceObject *pPOV)
 
 		//	If this is a completed non-player mission, then we delete it.
 
-		if (pMission->IsCompletedNonPlayer() || pMission->IsDestroyed())
+		if ((pMission->IsCompletedNonPlayer() && pMission->CleanNonPlayer()) || pMission->IsDestroyed())
 			{
 			m_AllMissions.Delete(i);
 			i--;


### PR DESCRIPTION
Adds a new attribute to keep/record completed non-player missions instead of deleting them when changing systems.

