### PR TITLE
Fixed (shpSetAISettings obj 'noFriendlyFire) not actually disabling friendly fire.

### DIFF
--- a/Include/TSE.h
+++ b/Include/TSE.h
@@ -1593,6 +1593,7 @@ class CSpaceObject : public CObject
 		inline void ClearCannotBeHit (void) { m_fCannotBeHit = false; }
 		inline void ClearInDamageCode (void) { m_fInDamage = false; }
 		inline void ClearInUpdateCode (void) { m_pObjInUpdate = NULL; m_bObjDestroyed = false; }
+		inline void ClearNoFriendlyFire(void) { m_fNoFriendlyFire = false; }
 		inline void ClearObjReferences (void) { m_Data.OnSystemChanged(NULL); }
 		inline void ClearPainted (void) { m_fPainted = false; }
 		inline void DisableObjectDestructionNotify (void) { m_fNoObjectDestructionNotify = true; }

--- a/Include/TSESpaceObjectsImpl.h
+++ b/Include/TSESpaceObjectsImpl.h
@@ -1222,6 +1222,7 @@ class CShip : public CSpaceObject
 		virtual void Suspend (void) override { Undock(); m_fManualSuspended = true; SetCannotBeHit(); }
 		virtual void Undock (CSpaceObject *pObj) override;
 		virtual void UpdateArmorItems (void) override;
+		void UpdateNoFriendlyFire(void);
 
 	protected:
 

--- a/TSE/CCExtensions.cpp
+++ b/TSE/CCExtensions.cpp
@@ -9584,6 +9584,7 @@ ICCItem *fnShipSet (CEvalContext *pEvalCtx, ICCItem *pArgs, DWORD dwData)
 			else
 				{
 				CString sNewValue = pShip->SetAISettingString(sSetting, (pValue->IsNil() ? NULL_STR : pValue->GetStringValue()));
+				pShip->UpdateNoFriendlyFire();
 				if (sNewValue.IsBlank())
 					return pCC->CreateNil();
 				else

--- a/TSE/CShip.cpp
+++ b/TSE/CShip.cpp
@@ -8219,3 +8219,16 @@ void CShip::UpdateInactive (void)
             }
         }
 	}
+
+void CShip::UpdateNoFriendlyFire(void)
+
+//	UpdateNoFriendlyFire
+//
+//	Updates NoFriendlyFire based on AISettings
+
+{
+	if (m_pController->GetAISettings()->NoFriendlyFire())
+		SetNoFriendlyFire();
+	else
+		ClearNoFriendlyFire();
+}


### PR DESCRIPTION
`(shpSetAISettings obj 'noFriendlyFire)` changed the `m_fNoFriendlyFire` variable in CAISettings, but it is the `m_fNoFriendlyFire` variable in CShip that actually determines whether or not friendly fire occurs. This change makes it so that `(shpSetAISettings obj 'noFriendlyFire)` will update both the CAISettings variable and the CShip variable.