### PR TITLE
Added delay for repeating weapons

### DIFF
--- a/Include/TSEDeviceClassesImpl.h
+++ b/Include/TSEDeviceClassesImpl.h
@@ -788,6 +788,7 @@ class CWeaponClass : public CDeviceClass
 						 int iRepeatingCount,
 						 bool *retbSourceDestroyed,
 						 bool *retbConsumedItems);
+		int GetContinuousFireDelay(CWeaponFireDesc *pShot) const;
 		int GetFireDelay (CWeaponFireDesc *pShot) const;
 		CWeaponFireDesc *GetReferenceShotData (CWeaponFireDesc *pShot, int *retiFragments = NULL) const;
 		int GetSelectVariantCount (void) const;
@@ -817,6 +818,7 @@ class CWeaponClass : public CDeviceClass
 		int m_iIdlePowerUse;					//	Power use when capacitors fully charged
 		int m_iRecoil;							//	0-7 (as per momentum damage)
 		int m_iFailureChance;					//	Chance of failure
+		int m_iContinuousFireDelay;				//	Ticks between continuous fire shots
 
 		bool m_bOmnidirectional;				//	Omnidirectional
 		bool m_bMIRV;							//	Each shot seeks an independent target


### PR DESCRIPTION
This change adds a new attribute to weapons: "repeatingDelay", which allows us to specify the number of ticks in between shots of a repeating weapon (like the Lancer or Moskva 33).