### PR TITLE
Added OnConsumeAmmo event to allow for variable ammunition consumption per shot.

### DIFF
--- a/Include/TSEDeviceClassesImpl.h
+++ b/Include/TSEDeviceClassesImpl.h
@@ -544,8 +544,9 @@ class CWeaponClass : public CDeviceClass
 		enum ECachedHandlers
 			{
 			evtOnFireWeapon				= 0,
+			evtOnConsumeAmmo			= 1,
 
-			evtCount					= 1,
+			evtCount					= 2,
 			};
 
         struct SBalance
@@ -775,6 +776,9 @@ class CWeaponClass : public CDeviceClass
 		bool ConsumeAmmo (CItemCtx &ItemCtx, CWeaponFireDesc *pShot, int iRepeatingCount, bool *retbConsumed);
 		bool ConsumeCapacitor (CItemCtx &ItemCtx, CWeaponFireDesc *pShot);
 		void FailureExplosion (CItemCtx &ItemCtx, CWeaponFireDesc *pShot, bool *retbSourceDestroyed);
+		int FireOnConsumeAmmo(CItemCtx &ItemCtx,
+							  CWeaponFireDesc *pShot,
+							  int iRepeatingCount);
 		EOnFireWeaponResults FireOnFireWeapon (CItemCtx &ItemCtx, 
 											   CWeaponFireDesc *pShot,
 											   const CVector &vSource,


### PR DESCRIPTION
This change adds a new event, <OnConsumeAmmo>, that allows for a weapon that consumes ammo or charges to consume more than one (or possibly zero) charges/items per shot. The weapon will not fire if there is less ammo/charges available than the number returned by OnConsumeAmmo. If OnConsumeAmmo returns a non-integer value, the weapon will consume one ammo.