### PR TITLE
Added new variant type: "`<Variants type="counter">`".

### DIFF
--- a/Include/TSEDeviceClassesImpl.h
+++ b/Include/TSEDeviceClassesImpl.h
@@ -716,6 +716,7 @@ class CWeaponClass : public CDeviceClass
 			varSingleLevelScaling,	//	Single CWeaponFireDesc, scales to levels
 			varLevelScaling,		//	Explicit definitions for each level
 			varCharges,				//	Current charge determines definition
+			varCounter,				//	Current counter value determines definition
 			};
 
 		struct SConfigDesc

--- a/Include/TSEItems.h
+++ b/Include/TSEItems.h
@@ -369,6 +369,7 @@ class CItem
 		inline CItemType *GetType (void) const { return m_pItemType; }
         int GetVariantHigh (void) const { return (m_pExtra ? (int)HIWORD(m_pExtra->m_dwVariant) : 0); }
         int GetVariantLow (void) const { return (m_pExtra ? (int)LOWORD(m_pExtra->m_dwVariant) : 0); }
+		inline int GetVariantNumber(void) const { return (m_pExtra ? (int)m_pExtra->m_dwVariantCounter : 0); }
 		bool HasComponents (void) const;
 		inline bool HasMods (void) const { return (m_pExtra && m_pExtra->m_Mods.IsNotEmpty()); }
 		bool HasSpecialAttribute (const CString &sAttrib) const;
@@ -396,6 +397,7 @@ class CItem
 		bool SetProperty (CItemCtx &Ctx, const CString &sName, ICCItem *pValue, CString *retsError);
         void SetVariantHigh (int iValue) { Extra(); m_pExtra->m_dwVariant = MAKELONG(LOWORD(m_pExtra->m_dwVariant), (WORD)(short)iValue); }
         void SetVariantLow (int iValue) { Extra(); m_pExtra->m_dwVariant = MAKELONG((WORD)(short)iValue, HIWORD(m_pExtra->m_dwVariant)); }
+		void SetVariantNumber (int iVariantCounter);
 
 		static CString GenerateCriteria (const CItemCriteria &Criteria);
 		static void InitCriteriaAll (CItemCriteria *retCriteria);
@@ -426,6 +428,7 @@ class CItem
 			DWORD m_dwCharges;					//	Charges for items
 			DWORD m_dwVariant;					//	Affects stats based on type (e.g., for armor, this is maxHP)
 			DWORD m_dwDisruptedTime;			//	If >0, the tick on which disruption expires
+			DWORD m_dwVariantCounter;			//	Counter for setting variants
 
 			CItemEnhancement m_Mods;			//	Class-specific modifications (e.g., armor enhancements)
 
@@ -563,6 +566,7 @@ class CItemCtx
 		const CItemEnhancementStack &GetEnhancements (void) { const CItemEnhancementStack *pStack = GetEnhancementStack(); if (pStack) return *pStack; else return *m_pNullEnhancements; }
 		const CItem &GetItem (void);
 		int GetItemCharges (void);
+		int GetItemVariantNumber (void);
 		const CItemEnhancement &GetMods (void);
 		inline CSpaceObject *GetSource (void) { return m_pSource; }
 		const CShipClass *GetSourceShipClass (void) const;

--- a/Include/TSEVersions.h
+++ b/Include/TSEVersions.h
@@ -7,7 +7,7 @@
 
 constexpr DWORD API_VERSION =							43;
 constexpr DWORD UNIVERSE_SAVE_VERSION =					35;
-constexpr DWORD SYSTEM_SAVE_VERSION =					168;
+constexpr DWORD SYSTEM_SAVE_VERSION =					169;
 
 //	Uncomment out the following define when building a stable release
 

--- a/TSE/CItem.cpp
+++ b/TSE/CItem.cpp
@@ -38,6 +38,7 @@
 #define PROPERTY_ROOT_NAME						CONSTLIT("rootName")
 #define PROPERTY_TRADE_ID						CONSTLIT("tradeID")
 #define PROPERTY_VALUE_BONUS_PER_CHARGE			CONSTLIT("valueBonusPerCharge")
+#define PROPERTY_VARIANT						CONSTLIT("variant")
 #define PROPERTY_USED							CONSTLIT("used")
 #define PROPERTY_WEAPON_TYPES					CONSTLIT("weaponTypes")
 
@@ -456,6 +457,7 @@ void CItem::Extra (void)
 		m_pExtra->m_dwCharges = 0;
 		m_pExtra->m_dwVariant = 0;
 		m_pExtra->m_dwDisruptedTime = 0;
+		m_pExtra->m_dwVariantCounter = 0;
 		}
 	}
 
@@ -1772,6 +1774,7 @@ bool CItem::IsExtraEmpty (const SExtra *pExtra, DWORD dwFlags)
 
 	return ((bIgnoreCharges || pExtra->m_dwCharges == 0)
 			&& pExtra->m_dwVariant == 0
+			&& pExtra->m_dwVariantCounter == 0
 			&& (bIgnoreDisrupted || (pExtra->m_dwDisruptedTime == 0 || pExtra->m_dwDisruptedTime < (DWORD)g_pUniverse->GetTicks()))
 			&& (bIgnoreEnhancements || pExtra->m_Mods.IsEmpty())
 			&& (bIgnoreData || pExtra->m_Data.IsEmpty()));
@@ -1795,6 +1798,7 @@ bool CItem::IsExtraEqual (SExtra *pSrc, DWORD dwFlags) const
 
 		return ((bIgnoreCharges || m_pExtra->m_dwCharges == pSrc->m_dwCharges)
 				&& m_pExtra->m_dwVariant == pSrc->m_dwVariant
+				&& m_pExtra->m_dwVariantCounter == pSrc->m_dwVariantCounter
 				&& (bIgnoreDisrupted || IsDisruptionEqual(m_pExtra->m_dwDisruptedTime, pSrc->m_dwDisruptedTime))
 				&& (bIgnoreEnhancements || m_pExtra->m_Mods.IsEqual(pSrc->m_Mods))
 				&& (bIgnoreData || m_pExtra->m_Data.IsEqual(pSrc->m_Data)));
@@ -2811,7 +2815,7 @@ void CItem::ReadFromCCItem (CCodeChain &CC, ICCItem *pBuffer)
 
 			//	Load the version, if we have it
 
-			DWORD dwVersion = 45;
+			DWORD dwVersion = 46;
 			if (pBuffer->GetCount() >= 7)
 				{
 				dwVersion = (DWORD)pBuffer->GetElement(iStart)->GetIntegerValue();
@@ -2848,6 +2852,11 @@ void CItem::ReadFromCCItem (CCodeChain &CC, ICCItem *pBuffer)
 
 			if (pBuffer->GetCount() >= 8)
 				m_pExtra->m_dwDisruptedTime = (DWORD)pBuffer->GetElement(iStart+4)->GetIntegerValue();
+
+			//	Variant number
+
+			if (pBuffer->GetCount() >= 9)
+				m_pExtra->m_dwVariantCounter = (DWORD)pBuffer->GetElement(iStart+5)->GetIntegerValue();
 			}
 		}
 	}
@@ -2896,6 +2905,14 @@ void CItem::ReadFromStream (SLoadCtx &Ctx)
 
 			m_pExtra->m_Mods.ReadFromStream(Ctx);
 			m_pExtra->m_Data.ReadFromStream(Ctx);
+			if (Ctx.dwVersion >= 169)
+				{
+				Ctx.pStream->Read((char *)&m_pExtra->m_dwDisruptedTime, sizeof(DWORD));
+				m_pExtra->m_dwVariantCounter = LOWORD(dwLoad);
+				}
+			else
+				m_pExtra->m_dwVariantCounter = 0;
+
 			}
 		else
 			m_pExtra = NULL;
@@ -2913,6 +2930,7 @@ void CItem::ReadFromStream (SLoadCtx &Ctx)
 			m_pExtra->m_dwCharges = dwCharges;
 			m_pExtra->m_dwVariant = 0;
 			m_pExtra->m_dwDisruptedTime = 0;
+			m_pExtra->m_dwVariantCounter = 0;
 			}
 		else
 			m_pExtra = NULL;
@@ -3094,6 +3112,16 @@ bool CItem::SetProperty (CItemCtx &Ctx, const CString &sName, ICCItem *pValue, C
 
         return true;
         }
+	else if (strEquals(sName, PROPERTY_VARIANT))
+	{
+		if (pValue == NULL || pValue->IsNil())
+		{
+			if (retsError) *retsError = NULL_STR;
+			return false;
+		}
+
+		SetVariantNumber(pValue->GetIntegerValue());
+	}
 
 	//	If this is an installed device, then pass it on
 
@@ -3110,6 +3138,18 @@ bool CItem::SetProperty (CItemCtx &Ctx, const CString &sName, ICCItem *pValue, C
 
 	return true;
 	}
+
+void CItem::SetVariantNumber(int iVariantCounter)
+
+		//	SetVariantNumber
+		//
+		//	Sets the current variant counter
+
+	{
+		Extra();
+		m_pExtra->m_dwVariantCounter = iVariantCounter;
+	}
+
 
 ICCItem *CItem::WriteToCCItem (CCodeChain &CC) const
 
@@ -3186,6 +3226,12 @@ ICCItem *CItem::WriteToCCItem (CCodeChain &CC) const
 		pInt = CC.CreateInteger(m_pExtra->m_dwDisruptedTime);
 		pList->Append(CC, pInt);
 		pInt->Discard(&CC);
+
+		//  Variant number
+
+		pInt = CC.CreateInteger(m_pExtra->m_dwVariantCounter);
+		pList->Append(CC, pInt);
+		pInt->Discard(&CC);
 		}
 
 	return pResult;
@@ -3207,6 +3253,7 @@ void CItem::WriteToStream (IWriteStream *pStream)
 //	DWORD		m_dwDisruptedTime
 //	CItemEnhancement
 //	CAttributeDataBlock
+//  DWORD		m_dwVariantCounter
 
 	{
 	DWORD dwSave = m_pItemType->GetUNID();
@@ -3230,6 +3277,8 @@ void CItem::WriteToStream (IWriteStream *pStream)
 		//	Note: Currently does not support saving object references
 
 		m_pExtra->m_Data.WriteToStream(pStream);
+		pStream->Write((char *)&m_pExtra->m_dwVariantCounter, sizeof(DWORD));
+
 		}
 	}
 

--- a/TSE/CItem.cpp
+++ b/TSE/CItem.cpp
@@ -3116,15 +3116,15 @@ bool CItem::SetProperty (CItemCtx &Ctx, const CString &sName, ICCItem *pValue, C
         return true;
         }
 	else if (strEquals(sName, PROPERTY_VARIANT))
-	{
-		if (pValue == NULL || pValue->IsNil())
 		{
+		if (pValue == NULL || pValue->IsNil())
+			{
 			if (retsError) *retsError = NULL_STR;
 			return false;
-		}
+			}
 
 		SetVariantNumber(pValue->GetIntegerValue());
-	}
+		}
 
 	//	If this is an installed device, then pass it on
 
@@ -3144,13 +3144,13 @@ bool CItem::SetProperty (CItemCtx &Ctx, const CString &sName, ICCItem *pValue, C
 
 void CItem::SetVariantNumber(int iVariantCounter)
 
-		//	SetVariantNumber
-		//
-		//	Sets the current variant counter
+//	SetVariantNumber
+//
+//	Sets the current variant counter
 
 	{
-		Extra();
-		m_pExtra->m_dwVariantCounter = iVariantCounter;
+	Extra();
+	m_pExtra->m_dwVariantCounter = iVariantCounter;
 	}
 
 
@@ -3256,7 +3256,7 @@ void CItem::WriteToStream (IWriteStream *pStream)
 //	DWORD		m_dwDisruptedTime
 //	CItemEnhancement
 //	CAttributeDataBlock
-//  DWORD		m_dwVariantCounter
+//	DWORD		m_dwVariantCounter
 
 	{
 	DWORD dwSave = m_pItemType->GetUNID();

--- a/TSE/CItem.cpp
+++ b/TSE/CItem.cpp
@@ -1336,6 +1336,9 @@ ICCItem *CItem::GetItemProperty (CCodeChainCtx &CCCtx, CItemCtx &Ctx, const CStr
 	else if (strEquals(sProperty, PROPERTY_USED))
 		return CC.CreateBool(IsUsed());
 
+	else if (strEquals(sProperty, PROPERTY_VARIANT))
+		return CC.CreateInteger(GetVariantNumber());
+
 	//	Next we handle all properties for devices, armor, etc. Note that this
 	//	includes both installed properties (e.g., armor segment) and static
 	//	properties (e.g., armor HP). But it DOES NOT include item type 

--- a/TSE/CItemCtx.cpp
+++ b/TSE/CItemCtx.cpp
@@ -300,6 +300,20 @@ const CItem *CItemCtx::GetItemPointer(void)
 	return NULL;
 	}
 
+int CItemCtx::GetItemVariantNumber(void)
+
+//	GetItemVariantNumber
+//
+//	Returns the variant number for the item (or 0).
+
+{
+	const CItem &Item = GetItem();
+	if (Item.IsEmpty())
+		return 0;
+
+	return Item.GetVariantNumber();
+}
+
 const CItemEnhancement &CItemCtx::GetMods(void)
 
 //	GetMods

--- a/TSE/CItemCtx.cpp
+++ b/TSE/CItemCtx.cpp
@@ -306,13 +306,13 @@ int CItemCtx::GetItemVariantNumber(void)
 //
 //	Returns the variant number for the item (or 0).
 
-{
+	{
 	const CItem &Item = GetItem();
 	if (Item.IsEmpty())
 		return 0;
 
 	return Item.GetVariantNumber();
-}
+	}
 
 const CItemEnhancement &CItemCtx::GetMods(void)
 

--- a/TSE/CWeaponClass.cpp
+++ b/TSE/CWeaponClass.cpp
@@ -3426,12 +3426,12 @@ CWeaponFireDesc *CWeaponClass::GetWeaponFireDesc (CItemCtx &ItemCtx, const CItem
 	//	Handle counter variants
 
 	else if (m_iVariantType == varCounter)
-	{
+		{
 		//	We assume that all charge values are represented in m_ShotData.
 
 		int iIndex = Min(Max(0, ItemCtx.GetItemVariantNumber()), m_ShotData.GetCount() - 1);
 		return m_ShotData[iIndex].pDesc;
-	}
+		}
 
     //  If we need ammo, then we have extra work to do.
     //  NOTE: Currently, if one variant uses ammo, all need to use ammo.

--- a/TSE/CWeaponClass.cpp
+++ b/TSE/CWeaponClass.cpp
@@ -101,6 +101,7 @@
 #define PROPERTY_STD_COST						CONSTLIT("stdCost")
 #define PROPERTY_TRACKING						CONSTLIT("tracking")
 
+#define VARIANT_TYPE_COUNTER					CONSTLIT("counter")
 #define VARIANT_TYPE_CHARGES					CONSTLIT("charges")
 #define VARIANT_TYPE_LEVELS						CONSTLIT("levels")
 #define VARIANT_TYPE_MISSILES					CONSTLIT("missiles")
@@ -3248,7 +3249,7 @@ int CWeaponClass::GetValidVariantCount (CSpaceObject *pSource, CInstalledDevice 
 	{
 	//	Special handling for scalable weapons
 
-	if (m_iVariantType == varLevelScaling || m_iVariantType == varCharges)
+	if (m_iVariantType == varLevelScaling || m_iVariantType == varCharges || m_iVariantType == varCounter)
 		{
 		CWeaponFireDesc *pShot = GetWeaponFireDesc(CItemCtx(pSource, pDevice));
 		if (pShot && VariantIsValid(pSource, pDevice, *pShot))
@@ -3422,6 +3423,16 @@ CWeaponFireDesc *CWeaponClass::GetWeaponFireDesc (CItemCtx &ItemCtx, const CItem
 		return m_ShotData[iIndex].pDesc;
 		}
 
+	//	Handle counter variants
+
+	else if (m_iVariantType == varCounter)
+	{
+		//	We assume that all charge values are represented in m_ShotData.
+
+		int iIndex = Min(Max(0, ItemCtx.GetItemVariantNumber()), m_ShotData.GetCount() - 1);
+		return m_ShotData[iIndex].pDesc;
+	}
+
     //  If we need ammo, then we have extra work to do.
     //  NOTE: Currently, if one variant uses ammo, all need to use ammo.
 	//	NOTE 2: This only applies to launchers. By definition, non-launchers
@@ -3532,6 +3543,8 @@ ALERROR CWeaponClass::InitVariantsFromXML (SDesignLoadCtx &Ctx, CXMLElement *pDe
 			m_iVariantType = varLauncher;
 		else if (strEquals(sType, VARIANT_TYPE_LEVELS))
 			m_iVariantType = varLevelScaling;
+		else if (strEquals(sType, VARIANT_TYPE_COUNTER))
+			m_iVariantType = varCounter;
 		else
 			{
 			Ctx.sError = strPatternSubst(CONSTLIT("Unknown variant type: %s"), sType);
@@ -4291,7 +4304,7 @@ bool CWeaponClass::SelectNextVariant (CSpaceObject *pSource, CInstalledDevice *p
 	//	For scaling, the descriptor to use is based on something other than the
 	//	selection, so we only one selection.
 
-	if (m_iVariantType == varLevelScaling || m_iVariantType == varCharges)
+	if (m_iVariantType == varLevelScaling || m_iVariantType == varCharges || m_iVariantType == varCounter)
 		{
 		CWeaponFireDesc *pShot = GetWeaponFireDesc(CItemCtx(pSource, pDevice));
 		if (pShot && VariantIsValid(pSource, pDevice, *pShot))


### PR DESCRIPTION
This functions identically to using `<Variants type="charges">`, except it uses its own dedicated variable instead of the charges variable. This allows us to use multiple-variant items while leaving the charges space free for purposes like e.g. multi-variant weapons that use charges.